### PR TITLE
Add ESLint/Prettier configs and scripts

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,20 @@
+{
+  "env": {
+    "browser": true,
+    "es2021": true
+  },
+  "extends": ["eslint:recommended", "plugin:react/recommended"],
+  "parserOptions": {
+    "ecmaFeatures": {
+      "jsx": true
+    },
+    "ecmaVersion": "latest",
+    "sourceType": "module"
+  },
+  "settings": {
+    "react": {
+      "version": "detect"
+    }
+  },
+  "rules": {}
+}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "trailingComma": "es5"
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "private": true,
   "scripts": {
     "start": "webpack serve --mode development --open",
-    "build": "webpack --mode production"
+    "build": "webpack --mode production",
+    "lint": "eslint src --ext .js,.jsx",
+    "format": "prettier --write \"src/**/*.{js,jsx,css,html,json}\""
   },
   "dependencies": {
     "react": "^18.2.0",
@@ -17,8 +19,10 @@
     "@babel/core": "^7.22.9",
     "@babel/preset-env": "^7.22.9",
     "@babel/preset-react": "^7.22.5",
-    "babel-loader": "^9.1.2"
-    ,"style-loader": "^3.3.3"
-    ,"css-loader": "^6.8.1"
+    "babel-loader": "^9.1.2",
+    "style-loader": "^3.3.3",
+    "css-loader": "^6.8.1",
+    "eslint": "^8.56.0",
+    "prettier": "^2.8.8"
   }
 }


### PR DESCRIPTION
## Summary
- add ESLint configuration for React
- add Prettier configuration
- add lint and format npm scripts
- include eslint and prettier as devDependencies

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.js file)*
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_685e9e1f58188325af2a5107e4299021