### PR TITLE
Add PropTypes to components

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "dependencies": {
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "prop-types": "^15.8.1"
   },
   "devDependencies": {
     "webpack": "^5.89.0",

--- a/src/components/About.jsx
+++ b/src/components/About.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 export default function About() {
   return (
     <div className="about-wrapper">
@@ -17,3 +18,5 @@ export default function About() {
     </div>
   );
 }
+
+About.propTypes = {};

--- a/src/components/ContactForm.jsx
+++ b/src/components/ContactForm.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import PropTypes from 'prop-types';
 
 export default function ContactForm() {
   const [form, setForm] = useState({ name: '', email: '', message: '' });
@@ -49,3 +50,5 @@ export default function ContactForm() {
     </form>
   );
 }
+
+ContactForm.propTypes = {};

--- a/src/components/DotsNav.jsx
+++ b/src/components/DotsNav.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 export default function DotsNav({ count, progress, onDotClick }) {
   const active = Math.round(progress * (count - 1));
@@ -14,3 +15,9 @@ export default function DotsNav({ count, progress, onDotClick }) {
     </div>
   );
 }
+
+DotsNav.propTypes = {
+  count: PropTypes.number.isRequired,
+  progress: PropTypes.number.isRequired,
+  onDotClick: PropTypes.func.isRequired
+};

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 export default function Footer() {
   return (
@@ -7,3 +8,5 @@ export default function Footer() {
     </footer>
   );
 }
+
+Footer.propTypes = {};

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 export default function Hero() {
   return (
@@ -11,3 +12,5 @@ export default function Hero() {
     </section>
   );
 }
+
+Hero.propTypes = {};

--- a/src/components/HorizontalScroller.jsx
+++ b/src/components/HorizontalScroller.jsx
@@ -4,11 +4,12 @@ import React, {
   forwardRef,
   useImperativeHandle
 } from 'react';
+import PropTypes from 'prop-types';
 import '../styles/main.css';
 
 const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
 
-function HorizontalScroller({ children, onProgress }, ref) {
+function HorizontalScrollerImpl({ children, onProgress }, ref) {
   const wrapperRef = useRef(null);
   const scrollRef = useRef(0);
   const maxScroll = useRef(0);
@@ -74,4 +75,15 @@ function HorizontalScroller({ children, onProgress }, ref) {
   );
 }
 
-export default forwardRef(HorizontalScroller);
+const HorizontalScroller = forwardRef(HorizontalScrollerImpl);
+
+HorizontalScroller.propTypes = {
+  children: PropTypes.node,
+  onProgress: PropTypes.func
+};
+
+HorizontalScroller.defaultProps = {
+  onProgress: undefined
+};
+
+export default HorizontalScroller;

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 export default function Navbar({ onNavClick }) {
   const sections = ['home', 'about', 'skills', 'projects', 'contact'];
@@ -24,3 +25,11 @@ export default function Navbar({ onNavClick }) {
     </nav>
   );
 }
+
+Navbar.propTypes = {
+  onNavClick: PropTypes.func
+};
+
+Navbar.defaultProps = {
+  onNavClick: undefined
+};

--- a/src/components/ProgressBar.jsx
+++ b/src/components/ProgressBar.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 export default function ProgressBar({ progress }) {
   return (
@@ -7,3 +8,11 @@ export default function ProgressBar({ progress }) {
     </div>
   );
 }
+
+ProgressBar.propTypes = {
+  progress: PropTypes.number
+};
+
+ProgressBar.defaultProps = {
+  progress: 0
+};

--- a/src/components/ProjectCard.jsx
+++ b/src/components/ProjectCard.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 export default function ProjectCard({ project }) {
   return (
@@ -20,3 +21,12 @@ export default function ProjectCard({ project }) {
     </div>
   );
 }
+
+ProjectCard.propTypes = {
+  project: PropTypes.shape({
+    id: PropTypes.number.isRequired,
+    title: PropTypes.string.isRequired,
+    description: PropTypes.string.isRequired,
+    link: PropTypes.string
+  }).isRequired
+};

--- a/src/components/Section.jsx
+++ b/src/components/Section.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 export default function Section({ id, title, children }) {
   return (
@@ -10,3 +11,9 @@ export default function Section({ id, title, children }) {
     </section>
   );
 }
+
+Section.propTypes = {
+  id: PropTypes.string.isRequired,
+  title: PropTypes.string.isRequired,
+  children: PropTypes.node
+};

--- a/src/components/Skills.jsx
+++ b/src/components/Skills.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 const skills = [
   { name: 'HTML/CSS', level: 80 },
@@ -24,3 +25,5 @@ export default function Skills() {
     </div>
   );
 }
+
+Skills.propTypes = {};


### PR DESCRIPTION
## Summary
- install `prop-types` dependency
- annotate every component in `src/components` with `propTypes`
- add default props where useful

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: webpack not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e9eddb3688325a845fd7c09fed9f5