### PR TITLE
Add dist directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules/
 .env
+
+dist/


### PR DESCRIPTION
## Summary
- prevent compiled assets from being tracked by ignoring `dist/`

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685ea020c0a083259f2b2860118f7fb2