### PR TITLE
Configure Jest testing

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  testEnvironment: 'jsdom',
+  transform: {
+    '^.+\\.[jt]sx?$': 'babel-jest'
+  },
+  moduleFileExtensions: ['js', 'jsx']
+};

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "start": "webpack serve --mode development --open",
-    "build": "webpack --mode production"
+    "build": "webpack --mode production",
+    "test": "jest"
   },
   "dependencies": {
     "react": "^18.2.0",
@@ -20,5 +21,8 @@
     "babel-loader": "^9.1.2"
     ,"style-loader": "^3.3.3"
     ,"css-loader": "^6.8.1"
+    ,"jest": "^29.6.1"
+    ,"@testing-library/react": "^14.0.0"
+    ,"babel-jest": "^29.6.1"
   }
 }

--- a/src/components/__tests__/HorizontalScroller.test.jsx
+++ b/src/components/__tests__/HorizontalScroller.test.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import HorizontalScroller from '../HorizontalScroller';
+
+test('renders children correctly', () => {
+  render(
+    <HorizontalScroller>
+      <div data-testid="child">Content</div>
+    </HorizontalScroller>
+  );
+  expect(screen.getByTestId('child')).toBeTruthy();
+});

--- a/src/components/__tests__/Navbar.test.jsx
+++ b/src/components/__tests__/Navbar.test.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import Navbar from '../Navbar';
+
+test('calls onNavClick when first link is clicked', () => {
+  const handleNavClick = jest.fn();
+  render(<Navbar onNavClick={handleNavClick} />);
+  const firstLink = screen.getByText(/HOME/i);
+  fireEvent.click(firstLink);
+  expect(handleNavClick).toHaveBeenCalledWith(0);
+});


### PR DESCRIPTION
## Summary
- add Jest and Testing Library dev dependencies
- configure Jest to use Babel
- add sample tests for Navbar and HorizontalScroller
- document `test` npm script

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ea0f01f448325be0bcd403bedceb4