### PR TITLE
Improve wheel paging for sections

### DIFF
--- a/src/components/HorizontalScroller.jsx
+++ b/src/components/HorizontalScroller.jsx
@@ -12,20 +12,17 @@ function HorizontalScroller({ children, onProgress }, ref) {
   const wrapperRef = useRef(null);
   const scrollRef = useRef(0);
   const maxScroll = useRef(0);
+  const pageCount = useRef(0);
+  const currentIndex = useRef(0);
+  const isScrolling = useRef(false);
 
   useEffect(() => {
     const wrapper = wrapperRef.current;
     const updateMaxScroll = () => {
       maxScroll.current = wrapper.scrollWidth - wrapper.clientWidth;
-    };
-    updateMaxScroll();
-    window.addEventListener('resize', updateMaxScroll);
-
-    const onWheel = (e) => {
-      e.preventDefault();
-      const delta = e.deltaY;
+      pageCount.current = wrapper.children.length;
       scrollRef.current = clamp(
-        scrollRef.current + delta,
+        currentIndex.current * window.innerWidth,
         0,
         maxScroll.current
       );
@@ -37,6 +34,39 @@ function HorizontalScroller({ children, onProgress }, ref) {
         onProgress(progress);
       }
     };
+    updateMaxScroll();
+    window.addEventListener('resize', updateMaxScroll);
+
+    const onWheel = (e) => {
+      e.preventDefault();
+      if (isScrolling.current) return;
+      isScrolling.current = true;
+      const delta = e.deltaY;
+      if (delta > 0) {
+        currentIndex.current = clamp(
+          currentIndex.current + 1,
+          0,
+          pageCount.current - 1
+        );
+      } else if (delta < 0) {
+        currentIndex.current = clamp(
+          currentIndex.current - 1,
+          0,
+          pageCount.current - 1
+        );
+      }
+      scrollRef.current = currentIndex.current * window.innerWidth;
+      wrapper.style.transform = `translateX(-${scrollRef.current}px)`;
+      if (onProgress) {
+        const progress = maxScroll.current
+          ? scrollRef.current / maxScroll.current
+          : 0;
+        onProgress(progress);
+      }
+      setTimeout(() => {
+        isScrolling.current = false;
+      }, 700);
+    };
 
     wrapper.addEventListener('wheel', onWheel, { passive: false });
     return () => {
@@ -47,8 +77,9 @@ function HorizontalScroller({ children, onProgress }, ref) {
 
   useImperativeHandle(ref, () => ({
     scrollTo(index) {
+      currentIndex.current = clamp(index, 0, pageCount.current - 1);
       scrollRef.current = clamp(
-        index * window.innerWidth,
+        currentIndex.current * window.innerWidth,
         0,
         maxScroll.current
       );


### PR DESCRIPTION
## Summary
- make horizontal scroller snap to full page per wheel event

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ea292a600832590f91d02a459f1a1