### PR TITLE
Add Experience section to home page

### DIFF
--- a/src/components/Experience.jsx
+++ b/src/components/Experience.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import experiences from '../data/experience';
+import '../styles/components/Experience.css';
+
+export default function Experience() {
+  return (
+    <ul className="experience-list">
+      {experiences.map((exp) => (
+        <li key={exp.id} className="experience-item">
+          <h3 className="experience-role">
+            {exp.role} <span className="experience-company">@ {exp.company}</span>
+          </h3>
+          <span className="experience-time">{exp.time}</span>
+          <p className="experience-description">{exp.description}</p>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -7,7 +7,7 @@ export default function Hero() {
       <div className="hero-inner">
         <h1>Hello, I'm Jane Doe</h1>
         <p className="tagline wave-underline glow-text">
-          Front-end Developer & Designer
+          Crafting delightful user experiences with React
         </p>
         <a className="cta sparkle-hover glow-border" href="#projects">
           View Projects

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useCallback } from 'react';
 
-const SECTIONS = ['home', 'about', 'skills', 'projects', 'contact'];
+const SECTIONS = ['home', 'about', 'skills', 'projects', 'experience', 'contact'];
 
 export default function Navbar({ onNavClick, defaultActive = 0 }) {
   const [activeIdx, setActiveIdx] = useState(defaultActive);

--- a/src/components/__tests__/Experience.test.jsx
+++ b/src/components/__tests__/Experience.test.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Experience from '../Experience';
+
+it('renders experience items', () => {
+  render(<Experience />);
+  const items = screen.getAllByRole('listitem');
+  expect(items.length).toBeGreaterThan(0);
+});

--- a/src/data/experience.js
+++ b/src/data/experience.js
@@ -1,0 +1,23 @@
+export default [
+  {
+    id: 1,
+    company: 'Tech Corp',
+    role: 'Front-end Developer',
+    time: '2021 - Present',
+    description: 'Developing responsive web interfaces and collaborating closely with designers.'
+  },
+  {
+    id: 2,
+    company: 'Creative Studio',
+    role: 'UI Designer',
+    time: '2019 - 2021',
+    description: 'Designed modern interfaces with a focus on accessibility and performance.'
+  },
+  {
+    id: 3,
+    company: 'Freelance',
+    role: 'Web Developer',
+    time: '2017 - 2019',
+    description: 'Built websites for small businesses using React and WordPress.'
+  }
+];

--- a/src/pages/App.jsx
+++ b/src/pages/App.jsx
@@ -9,6 +9,7 @@ import About from '../components/About';
 import ProjectCard from '../components/ProjectCard';
 import ContactForm from '../components/ContactForm';
 import ProgressBar from '../components/ProgressBar';
+import Experience from '../components/Experience';
 import projects from '../data/projects';
 
 export default function App() {
@@ -41,6 +42,9 @@ export default function App() {
               <ProjectCard key={p.id} project={p} />
             ))}
           </div>
+        </Section>
+        <Section id="experience" title="Experience">
+          <Experience />
         </Section>
         <Section id="contact" title="Contact">
           <ContactForm />

--- a/src/styles/components/Experience.css
+++ b/src/styles/components/Experience.css
@@ -1,0 +1,34 @@
+.experience-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.experience-item {
+  background: rgba(255, 255, 255, 0.8);
+  padding: 1rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.experience-role {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.experience-company {
+  font-weight: normal;
+  color: #555;
+}
+
+.experience-time {
+  font-size: 0.9rem;
+  color: #666;
+}
+
+.experience-description {
+  margin-top: 0.5rem;
+  line-height: 1.4;
+}


### PR DESCRIPTION
## Summary
- add Experience component with list of work history
- load new experience data and styles
- insert Experience section into page layout
- update navbar sections and hero tagline
- add unit test for Experience component

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eb72640fc832594df99bf28e54b69